### PR TITLE
Feature improvement video performance

### DIFF
--- a/lib/three-shader.js
+++ b/lib/three-shader.js
@@ -128,11 +128,13 @@ export default class ThreeShader {
    * @param {string} textureUrl
    */
   loadTexture(name, textureUrl) {
-    const texture = isVideo(textureUrl) ? this.videoLoader.load(textureUrl) : this.textureLoader.load(textureUrl);
-    this.uniforms[name] = {
-      type: 't',
-      value: texture,
-    };
+    const texture = isVideo(textureUrl) ? this.videoLoader.load(name, textureUrl) : this.textureLoader.load(textureUrl);
+    if(texture){
+      this.uniforms[name] = {
+        type: 't',
+        value: texture,
+      };
+    }
   }
 
   /**

--- a/lib/video-loader.js
+++ b/lib/video-loader.js
@@ -2,18 +2,36 @@
 import * as THREE from 'three';
 
 export default class VideoLoader {
-  load(url) {
-    const video = document.createElement('video');
-    video.src = url;
-    video.autoplay = true;
-    video.loop = true;
-    video.muted = true;
-    video.style.top = 999999;
-    document.body.appendChild(video);
-
+  load(id, url) {
+    let sameIdVideos = Array.from(document.getElementsByTagName( "video" )).filter((element, index) => {
+      return element.id==id;
+    });
+    let sameIdVideo = sameIdVideos.length>0?sameIdVideos[0]:null;
+    let video;
+    if(sameIdVideo){
+      video = sameIdVideo;
+      if(video.name == url){
+        return null;
+      }else{
+        video.name = url;
+        video.src = url;
+      }
+    }else{
+      video = document.createElement('video');
+      document.body.appendChild(video);
+      video.id = id;
+      video.name = url;
+      video.src = url;
+      video.autoplay = true;
+      video.loop = true;
+      video.muted = true;
+      video.style.top = 999999;
+    }
     const texture = new THREE.VideoTexture(video);
     texture.format = THREE.RGBFormat;
-
     return texture;
+  }
+
+  remove(id){
   }
 }


### PR DESCRIPTION
On the current implementation, whenever an user saves .liverc file, VideoLoader adds a new video tag to DOM each time. So, this affects CPU load. This commit change it to that a loader overwrite to a existing video tag.