### PR TITLE
Adjust style

### DIFF
--- a/styles/glsl-livecoder.less
+++ b/styles/glsl-livecoder.less
@@ -20,7 +20,8 @@ body.glsl-livecoder-enabled {
   .footer *,
   atom-workspace-axis,
   atom-workspace-axis :not(.cursor):not(autocomplete-suggestion-list):not(atom-overlay):not(span):not(.region),
-  atom-workspace *:before {
+  atom-workspace *:before,
+  atom-workspace *:after {
     background: transparent !important;
     border: none !important;
     text-shadow: 0 1px 1px black;


### PR DESCRIPTION
This PR adjust the stylesheet. A part of tab(`:after`) was displayed.

## before 

<img width="488" alt="2017-08-07 20 03 59" src="https://user-images.githubusercontent.com/630181/29070070-885800f0-7c78-11e7-921d-3daddb0d2d90.png">

## after

<img width="496" alt="2017-08-07 20 03 04" src="https://user-images.githubusercontent.com/630181/29070078-8eb95e62-7c78-11e7-8844-d27f7c291bac.png">

