### PR TITLE
Feature caching all midi messages on a midi texture

### DIFF
--- a/lib/midi-loader.js
+++ b/lib/midi-loader.js
@@ -3,14 +3,14 @@ import * as THREE from 'three';
 
 export default class MidiLoader {
   constructor() {
-    this.midiArray = new Uint8Array(256 * 4);
+    this.midiArray = new Uint8Array(256*128);
     this.noteArray = new Uint8Array(128);
 
     this.texture = new THREE.DataTexture(
       this.midiArray,
       256,
-      1,
-      THREE.RGBAFormat,
+      128,
+      THREE.LuminanceFormat,
       THREE.UnsignedByteType
     );
     this.noteTexture = new THREE.DataTexture(
@@ -35,9 +35,8 @@ export default class MidiLoader {
   }
 
   onmidimessage = midi => {
-    const offset = midi[0] * 4;
-    this.midiArray[offset] = midi[1];
-    this.midiArray[offset + 1] = midi[2];
+    const offset = midi[0] + midi[1] * 256;
+    this.midiArray[offset] = midi[2];
     this.texture.needsUpdate = true;
 
     // note on


### PR DESCRIPTION
This change assigns midi message's 1st and 2nd byte to each coordinates of midi texture. 3rd byte to each pixel as luminance. 
Example of getting for midi controller status are bellow.
```
float p = texture2D(midi, vec2(176.0+channel, controlNumber)/vec2(256.0,128.0)).r*2.0;
```

NOTE:
Sometime in the future,  this assigning will have to be restricted appropriately for status byte.
