### PR TITLE
fix #14

### DIFF
--- a/lib/glsl-livecoder.js
+++ b/lib/glsl-livecoder.js
@@ -136,9 +136,11 @@ export default class GlslLivecoder {
     this._state.editor = editor;
     this.loadShaderOfEditor(editor);
 
-    this._state.editorDisposer = editor.onDidStopChanging(() => {
-      this.loadShaderOfEditor(editor);
-    });
+    if(editor !== undefined){
+      this._state.editorDisposer = editor.onDidStopChanging(() => {
+        this.loadShaderOfEditor(editor);
+      });
+    }
   }
 
   loadShader(): void {
@@ -175,7 +177,7 @@ export default class GlslLivecoder {
   * @private
   */
   loadShaderOfEditor(editor: TextEditor): void {
-    if(editor == undefined){
+    if(editor === undefined){
       // This case occurs when no files are open/active
       return; 
     }

--- a/lib/glsl-livecoder.js
+++ b/lib/glsl-livecoder.js
@@ -175,6 +175,10 @@ export default class GlslLivecoder {
   * @private
   */
   loadShaderOfEditor(editor: TextEditor): void {
+    if(editor == undefined){
+      // This case occurs when no files are open/active
+      return; 
+    }
     const path = editor.getPath();
     const m = (path || '').match(/(\.(?:glsl|frag|vert))$/);
     if (!m) {


### PR DESCRIPTION
Doing an early return when `editor` is undefined fixed the problem for me.
I don't do atom plugin development so if there's a more elegant atom plugin way to go about this, please lmk :)