### PR TITLE
Fix convertPathForServer for Windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,11 @@ export function convertPathForServer(
     }
 
     // Get relative path from projectPath
-    const relativePath = path.relative(projectPath, target);
+    let relativePath = path.relative(projectPath, target);
+
+    if (path.sep === '\\') {
+        relativePath = relativePath.replace(/\\/g, '/');
+    }
 
     return `http://localhost:${port}/link/${relativePath}`;
 }


### PR DESCRIPTION
Fix fand/veda#97.

For a unknown reason, `npm run ci` does not support `new RegExp(path.sep, 'g')`, so I hardcoded the literal form.