### PR TITLE
Update package.json to include latest vedajs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "socket.io-client": "^2.2.0",
         "three": "^0.116.1",
         "tmp": "^0.2.1",
-        "vedajs": "^0.15.0",
+        "vedajs": "^0.16.0",
         "which": "^2.0.2"
     },
     "package-deps": [


### PR DESCRIPTION
Fixes issue with `lib/camera-loader` using removed `createObjectURL` method call in webcam examples.